### PR TITLE
Use asyncio for concurrent RSS fetching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ spacy==3.7.2
 textstat==0.7.3
 python-dateutil==2.8.2
 nltk==3.8.1
+aiohttp==3.9.5

--- a/scripts/enhanced_fetch.py
+++ b/scripts/enhanced_fetch.py
@@ -1,21 +1,27 @@
-import feedparser
-import yaml
+"""Enhanced asynchronous article fetching and processing."""
+
+import asyncio
+import glob
+import hashlib
 import json
 import os
-import argparse
-from datetime import datetime, timedelta
-from dateutil import parser as date_parser
-import glob
-from typing import List, Dict, Set, Optional
-import hashlib
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+from functools import partial
+from typing import Dict, List, Optional, Set
+
+import aiohttp
+import feedparser
+import yaml
+from dateutil import parser as date_parser
+
 from enhanced_utils import (
-    enhanced_summarize_article,
-    get_article_content,
     detect_duplicate_content,
-    score_article_relevance,
+    enhanced_summarize_article,
     extract_breaking_news_indicators,
-    score_article_sentiment
+    get_article_content,
+    score_article_relevance,
+    score_article_sentiment,
 )
 
 @dataclass
@@ -93,101 +99,119 @@ def enhance_source_metadata(source: Dict) -> Dict:
     }
     return {**source, **enhancements}
 
-def fetch_enhanced_articles(config_path: str = "feeds/enhanced_sources.yaml") -> List[Article]:
-    """Enhanced article fetching with smart filtering and deduplication.
+async def fetch_feed(session: aiohttp.ClientSession, url: str) -> feedparser.FeedParserDict:
+    """Fetch and parse an RSS/Atom feed asynchronously."""
+    async with session.get(url) as resp:
+        text = await resp.text()
+    return feedparser.parse(text)
 
-    Parameters
-    ----------
-    config_path: str
-        Path to YAML configuration file describing the news sources.
-    """
+
+async def _process_source(
+    session: aiohttp.ClientSession,
+    source: Dict,
+    existing_hashes: Set[str],
+) -> List[Article]:
+    """Fetch and process a single source."""
+    loop = asyncio.get_running_loop()
+    articles: List[Article] = []
+
+    source = enhance_source_metadata(source)
+
+    try:
+        if source["type"] == "rss":
+            feed = await fetch_feed(session, source["url"])
+
+            # Get more articles for high-priority sources
+            max_articles = source["max_articles"]
+            if source.get("priority") == "high":
+                max_articles *= 2
+
+            for entry in feed.entries[:max_articles]:
+                published = entry.get("published") or entry.get("updated") or ""
+                if not is_recent_article(published, hours_threshold=24 * 7):
+                    continue
+
+                content_hash = create_content_hash(entry.title, entry.link)
+                if content_hash in existing_hashes:
+                    continue
+
+                article_content = await loop.run_in_executor(
+                    None, get_article_content, entry.link
+                )
+
+                is_breaking = extract_breaking_news_indicators(
+                    entry.title,
+                    article_content,
+                    source.get("relevance_keywords", []),
+                )
+
+                relevance_score = score_article_relevance(
+                    entry.title,
+                    article_content,
+                    source.get("topics", []),
+                    source.get("relevance_keywords", []),
+                )
+
+                if relevance_score < 0.3 and not is_breaking:
+                    continue
+
+                fallback = getattr(entry, "summary", "") or getattr(entry, "description", "")
+                sentiment_score = score_article_sentiment(article_content or fallback)
+                summarize = partial(
+                    enhanced_summarize_article,
+                    entry.link,
+                    article_content or fallback,
+                    is_breaking=is_breaking,
+                    relevance_score=relevance_score,
+                )
+                summary = await loop.run_in_executor(None, summarize)
+
+                article = Article(
+                    source=source["name"],
+                    title=entry.title,
+                    url=entry.link,
+                    published=published,
+                    published_dt=parse_published_date(published),
+                    summary=summary,
+                    topics=source.get("topics", []),
+                    content_hash=content_hash,
+                    relevance_score=relevance_score,
+                    sentiment_score=sentiment_score,
+                    is_breaking=is_breaking,
+                )
+
+                articles.append(article)
+                existing_hashes.add(content_hash)
+
+    except Exception as e:
+        print(f"Error processing source {source['name']}: {e}")
+
+    return articles
+
+
+async def fetch_enhanced_articles(
+    config_path: str = "feeds/enhanced_sources.yaml",
+) -> List[Article]:
+    """Enhanced article fetching with smart filtering and deduplication."""
 
     with open(config_path) as f:
         sources = yaml.safe_load(f)
-    
+
     existing_hashes = load_existing_articles()
-    articles = []
-    
+
     # Prioritize high-priority sources for breaking news
-    sources.sort(key=lambda x: {"high": 0, "medium": 1, "low": 2}.get(x.get("priority", "medium"), 1))
-    
-    for source in sources:
-        source = enhance_source_metadata(source)
-        
-        try:
-            if source["type"] == "rss":
-                feed = feedparser.parse(source["url"])
-                
-                # Get more articles for high-priority sources
-                max_articles = source["max_articles"]
-                if source.get("priority") == "high":
-                    max_articles *= 2
-                
-                for entry in feed.entries[:max_articles]:
-                    # Skip articles older than 7 days unless it's breaking news
-                    published = entry.get("published") or entry.get("updated") or ""
-                    if not is_recent_article(published, hours_threshold=24 * 7):
-                        continue
-                    
-                    # Create content hash for deduplication
-                    content_hash = create_content_hash(entry.title, entry.link)
-                    if content_hash in existing_hashes:
-                        continue
-                    
-                    # Get article content for better analysis
-                    article_content = get_article_content(entry.link)
-                    
-                    # Check for breaking news indicators
-                    is_breaking = extract_breaking_news_indicators(
-                        entry.title, 
-                        article_content,
-                        source.get("relevance_keywords", [])
-                    )
-                    
-                    # Score relevance
-                    relevance_score = score_article_relevance(
-                        entry.title,
-                        article_content,
-                        source.get("topics", []),
-                        source.get("relevance_keywords", [])
-                    )
-                    
-                    # Skip low-relevance articles unless breaking
-                    if relevance_score < 0.3 and not is_breaking:
-                        continue
-                    
-                    # Sentiment analysis and summarization
-                    fallback = getattr(entry, "summary", "") or getattr(entry, "description", "")
-                    sentiment_score = score_article_sentiment(article_content or fallback)
-                    summary = enhanced_summarize_article(
-                        entry.link,
-                        article_content or fallback,
-                        is_breaking=is_breaking,
-                        relevance_score=relevance_score
-                    )
-                    
-                    article = Article(
-                        source=source["name"],
-                        title=entry.title,
-                        url=entry.link,
-                        published=published,
-                        published_dt=parse_published_date(published),
-                        summary=summary,
-                        topics=source.get("topics", []),
-                        content_hash=content_hash,
-                        relevance_score=relevance_score,
-                        sentiment_score=sentiment_score,
-                        is_breaking=is_breaking
-                    )
-                    
-                    articles.append(article)
-                    existing_hashes.add(content_hash)
-        
-        except Exception as e:
-            print(f"Error processing source {source['name']}: {e}")
-            continue
-    
-    # Sort by breaking news first, then relevance, then recency
+    sources.sort(
+        key=lambda x: {"high": 0, "medium": 1, "low": 2}.get(x.get("priority", "medium"), 1)
+    )
+
+    async with aiohttp.ClientSession() as session:
+        tasks = [
+            _process_source(session, src, existing_hashes) for src in sources
+        ]
+        results = await asyncio.gather(*tasks)
+
+    articles = [article for group in results for article in group]
+
     articles.sort(
         key=lambda x: (
             not x.is_breaking,
@@ -196,21 +220,19 @@ def fetch_enhanced_articles(config_path: str = "feeds/enhanced_sources.yaml") ->
         ),
         reverse=False,
     )
-    
+
     return articles
 
-def main():
-    """Main execution function."""
-    articles = fetch_enhanced_articles()
+async def main() -> None:
+    """Main asynchronous execution function."""
+    articles = await fetch_enhanced_articles()
 
-    # Detect and filter duplicate content
     duplicate_urls = detect_duplicate_content(
         [{"title": a.title, "url": a.url} for a in articles]
     )
     if duplicate_urls:
         articles = [a for a in articles if a.url not in duplicate_urls]
-    
-    # Convert to JSON format
+
     summaries = []
     for article in articles:
         summary_data = {
@@ -223,29 +245,28 @@ def main():
             "content_hash": article.content_hash,
             "relevance_score": round(article.relevance_score, 2),
             "sentiment_score": round(article.sentiment_score, 2),
-            "is_breaking": article.is_breaking
+            "is_breaking": article.is_breaking,
         }
         summaries.append(summary_data)
-    
-    # Limit total articles to prevent overwhelming
+
     summaries = summaries[:50]
-    
-    # Save with metadata
+
     output = {
         "generated_at": datetime.now().isoformat(),
         "total_articles": len(summaries),
         "breaking_news_count": sum(1 for s in summaries if s["is_breaking"]),
-        "articles": summaries
+        "articles": summaries,
     }
-    
+
     os.makedirs("data", exist_ok=True)
     today = datetime.utcnow().strftime("%Y-%m-%d")
     output_file = f"data/summaries_{today}.json"
     with open(output_file, "w") as f:
         json.dump(output, f, indent=2)
-    
+
     print(f"✅ Processed {len(summaries)} articles ({output['breaking_news_count']} breaking)")
 
+
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())
 

--- a/scripts/fetch_articles.py
+++ b/scripts/fetch_articles.py
@@ -1,70 +1,111 @@
-import feedparser
-import yaml
+"""Fetch and summarize articles asynchronously."""
+
+import asyncio
 import json
 import os
 from datetime import datetime, timedelta
+
+import aiohttp
+import feedparser
+import yaml
 from dateutil import parser as date_parser
-from utils import summarize_article, scrape_blog
 
-with open("feeds/sources.yaml") as f:
-    sources = yaml.safe_load(f)
+from utils import scrape_blog, summarize_article
 
-summaries = []
-cutoff = datetime.utcnow() - timedelta(days=7)
 
-for source in sources:
-    if source["type"] == "rss":
-        feed = feedparser.parse(source["url"])
-        for entry in feed.entries[:3]:
-            published = entry.get("published") or entry.get("updated") or ""
-            try:
-                pub_date = date_parser.parse(published)
-                if pub_date.tzinfo:
-                    pub_date = pub_date.astimezone(None).replace(tzinfo=None)
-            except Exception:
-                pub_date = None
+async def fetch_feed(session: aiohttp.ClientSession, url: str) -> feedparser.FeedParserDict:
+    """Retrieve and parse an RSS/Atom feed asynchronously."""
+    async with session.get(url) as resp:
+        text = await resp.text()
+    return feedparser.parse(text)
 
-            if pub_date and pub_date < cutoff:
-                continue
 
-            fallback = getattr(entry, "summary", "") or getattr(entry, "description", "")
-            summary = summarize_article(entry.link, fallback)
-            summaries.append({
-                "source": source["name"],
-                "title": entry.title,
-                "url": entry.link,
-                "published": published,
-                "summary": summary,
-                "topics": source.get("topics", [])
-            })
+async def process_rss_source(session: aiohttp.ClientSession, source: dict, cutoff: datetime) -> list:
+    """Process a single RSS source and return summary entries."""
+    loop = asyncio.get_running_loop()
+    feed = await fetch_feed(session, source["url"])
+    entries = []
+    for entry in feed.entries[:3]:
+        published = entry.get("published") or entry.get("updated") or ""
+        try:
+            pub_date = date_parser.parse(published)
+            if pub_date.tzinfo:
+                pub_date = pub_date.astimezone(None).replace(tzinfo=None)
+        except Exception:
+            pub_date = None
 
-    elif source["type"] == "scrape":
-        scraped = scrape_blog(source["url"])
-        for entry in scraped[:3]:
-            pub_date_str = entry.get("date", "")
-            try:
-                pub_date = date_parser.parse(pub_date_str)
-                if pub_date.tzinfo:
-                    pub_date = pub_date.astimezone(None).replace(tzinfo=None)
-            except Exception:
-                pub_date = None
+        if pub_date and pub_date < cutoff:
+            continue
 
-            if pub_date and pub_date < cutoff:
-                continue
+        fallback = getattr(entry, "summary", "") or getattr(entry, "description", "")
+        summary = await loop.run_in_executor(None, summarize_article, entry.link, fallback)
+        entries.append({
+            "source": source["name"],
+            "title": entry.title,
+            "url": entry.link,
+            "published": published,
+            "summary": summary,
+            "topics": source.get("topics", []),
+        })
+    return entries
 
-            summary = summarize_article(entry["url"], entry.get("summary"))
-            summaries.append({
-                "source": source["name"],
-                "title": entry["title"],
-                "url": entry["url"],
-                "published": pub_date_str,
-                "summary": summary,
-                "topics": source.get("topics", [])
-            })
 
-os.makedirs("data", exist_ok=True)
-today = datetime.utcnow().strftime("%Y-%m-%d")
-output_file = f"data/summaries_{today}.json"
-with open(output_file, "w") as f:
-    json.dump(summaries, f, indent=2)
+async def process_scrape_source(session: aiohttp.ClientSession, source: dict, cutoff: datetime) -> list:
+    """Process a scraped source asynchronously."""
+    loop = asyncio.get_running_loop()
+    scraped = await loop.run_in_executor(None, scrape_blog, source["url"])
+    entries = []
+    for entry in scraped[:3]:
+        pub_date_str = entry.get("date", "")
+        try:
+            pub_date = date_parser.parse(pub_date_str)
+            if pub_date.tzinfo:
+                pub_date = pub_date.astimezone(None).replace(tzinfo=None)
+        except Exception:
+            pub_date = None
+
+        if pub_date and pub_date < cutoff:
+            continue
+
+        summary = await loop.run_in_executor(None, summarize_article, entry["url"], entry.get("summary"))
+        entries.append({
+            "source": source["name"],
+            "title": entry["title"],
+            "url": entry["url"],
+            "published": pub_date_str,
+            "summary": summary,
+            "topics": source.get("topics", []),
+        })
+    return entries
+
+
+async def main() -> None:
+    with open("feeds/sources.yaml") as f:
+        sources = yaml.safe_load(f)
+
+    summaries: list = []
+    cutoff = datetime.utcnow() - timedelta(days=7)
+
+    async with aiohttp.ClientSession() as session:
+        tasks = []
+        for source in sources:
+            if source["type"] == "rss":
+                tasks.append(process_rss_source(session, source, cutoff))
+            elif source["type"] == "scrape":
+                tasks.append(process_scrape_source(session, source, cutoff))
+
+        results = await asyncio.gather(*tasks)
+
+    for group in results:
+        summaries.extend(group)
+
+    os.makedirs("data", exist_ok=True)
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    output_file = f"data/summaries_{today}.json"
+    with open(output_file, "w") as f:
+        json.dump(summaries, f, indent=2)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 


### PR DESCRIPTION
## Summary
- refactor article fetch scripts to use asyncio and aiohttp for concurrent RSS retrieval
- replace direct feedparser calls with async HTTP requests and parsing
- run blocking summarization and scraping in a thread pool to avoid blocking the event loop

## Testing
- `python -m py_compile scripts/fetch_articles.py scripts/enhanced_fetch.py`

------
https://chatgpt.com/codex/tasks/task_e_68952e3ad1888321b4ba58e12e646d3a